### PR TITLE
replace native console log with strapi logger

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -16,10 +16,10 @@ module.exports = async ({ strapi }) => {
         // permission no found
         if (!selectedRole.permissions.find(p => p.action === route.perm_action)) {
           if (prevsRouteConfig.find(r => r.action === route.perm_action && r.role.id === selectedRole.id)) {
-            console.log(`Permission on role ${role} ::::: ${route.perm_action} was removed from admin`)
+            strapi.log.info(`Permission on role ${role} ::::: ${route.perm_action} was removed from admin`)
             return null;
           } else {
-            console.log(`Generating permission on role ${role} ::::: ${route.perm_action}`)
+            strapi.log.info(`Generating permission on role ${role} ::::: ${route.perm_action}`)
             counterPermUpdated++;
             await strapi.entityService.create('plugin::route-permission.route-permission', {
               data: {
@@ -38,5 +38,5 @@ module.exports = async ({ strapi }) => {
       }
     })
   }
-  console.log(`Route permission plugin ::::: ${counterPermUpdated} generated permissions `)
+  strapi.log.info(`Route permission plugin ::::: ${counterPermUpdated} generated permissions `)
 };

--- a/server/controllers/admin-route-permission.js
+++ b/server/controllers/admin-route-permission.js
@@ -40,7 +40,7 @@ module.exports = {
       const pageSize = ctx.query.pageSize || 10;
       const start = pageSize * (ctx.query.page - 1);
       const end = Number(start) + pageSize;
-      console.log(start, end)
+      strapi.log.info(start, end)
       configuredRoutes = configuredRoutes.splice(start, end)
     }
     ctx.body = {


### PR DESCRIPTION
Replace native console log with strapi logger for utilization of strapis logger winston. With the strapi logger you can define some transport adapters for the logs.